### PR TITLE
fix: improve reproducibility by seeding all randomness sources

### DIFF
--- a/src/DQN.py
+++ b/src/DQN.py
@@ -13,7 +13,7 @@ import argparse
 import os
 import torch
 import numpy as np
-
+import random
 
 def warn(*args, **kwargs):
     pass
@@ -65,10 +65,16 @@ def get_player(directory=None, files_list=None, landmark_ids=None, viz=False,
 ###############################################################################
 
 def set_reproducible(seed):
+    # Note: For full reproducibility, set PYTHONHASHSEED before running the script
+    # e.g., PYTHONHASHSEED=42 python src/DQN.py --seed 42
+    random.seed(seed)
+    np.random.seed(seed)
     torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
     torch.backends.cudnn.deterministic = True
     torch.backends.cudnn.benchmark = False
-    np.random.seed(seed)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Extended the `set_reproducible` function to cover the remaining sources of randomness
1. Added seeding for python’s built in `random` module
2. Added CUDA seeding (`torch.cuda.manual_seed` and `torch.cuda.manual_seed_all`)

Before
```python 
def set_reproducible(seed):
    torch.manual_seed(seed)
    torch.backends.cudnn.deterministic = True
    torch.backends.cudnn.benchmark = False
    np.random.seed(seed)
```
After 
```python 
def set_reproducible(seed):
    # Note: For full reproducibility, set PYTHONHASHSEED before running the script
    # e.g., PYTHONHASHSEED=42 python src/DQN.py --seed 42
    random.seed(seed)
    np.random.seed(seed)
    torch.manual_seed(seed)
    if torch.cuda.is_available():
        torch.cuda.manual_seed(seed)
        torch.cuda.manual_seed_all(seed)
    torch.backends.cudnn.deterministic = True
    torch.backends.cudnn.benchmark = False
```
still, full determinism may depend on the environment but this will improve reproducibility on the training side