### PR TITLE
fix:  device handling in evaluator and DQN (ensure model/input device consistency)

### DIFF
--- a/src/DQN.py
+++ b/src/DQN.py
@@ -217,8 +217,11 @@ if __name__ == '__main__':
     if args.task != 'train':
         dqn = DQN(agents, frame_history=FRAME_HISTORY, logger=logger,
                   type=args.model_name, collective_rewards=args.team_reward, attention=args.attention)
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         model = dqn.q_network
-        model.load_state_dict(torch.load(args.load, map_location=model.device))
+        model.load_state_dict(torch.load(args.load, map_location=device))
+        model.to(device)
+        model.eval()
         environment = get_player(files_list=args.files,
                                  file_type=args.file_type,
                                  landmark_ids=args.landmarks,

--- a/src/evaluator.py
+++ b/src/evaluator.py
@@ -67,18 +67,19 @@ class Evaluator(object):
         return mean, std
 
     def play_one_episode(self, render=False, frame_history=4, fixed_spawn=None):
-
+        device = next(self.model.parameters()).device
         def predict(obs_stack):
             """
             Run a full episode, mapping observation to action,
             using greedy policy.
             """
-            inputs = torch.tensor(obs_stack).permute(
-                0, 4, 1, 2, 3).unsqueeze(0)
-            q_vals = self.model.forward(inputs).detach().squeeze(0)
+            inputs = torch.from_numpy(obs_stack).float().permute(
+                0, 4, 1, 2, 3).unsqueeze(0).to(device)
+            with torch.no_grad(): 
+                q_vals = self.model(inputs)
             idx = torch.max(q_vals, -1)[1]
             greedy_steps = np.array(idx, dtype=np.int32).flatten()
-            return greedy_steps, q_vals.data.numpy()
+            return greedy_steps, q_vals.detach().cpu().numpy()
 
         obs_stack = self.env.reset(fixed_spawn)
         # Here obs have shape (agent, *image_size, frame_history)


### PR DESCRIPTION
fixes #23 

got engaged in some college stuff so didnt get time to fix it, okay so i looked into the device handling across the evaluator and model loading and made it explicit while keeping the current cpu behaviour intact 

made sure that the model is always moved to a defined device (cpu/gpu) and inputs in the evaluator are moved to the same device before the forward pass, hence avoiding potential device mismatch issues

