### PR TITLE
feat: add checkpoint saving and resume support for training

### DIFF
--- a/src/DQN.py
+++ b/src/DQN.py
@@ -217,8 +217,11 @@ if __name__ == '__main__':
     if args.task != 'train':
         dqn = DQN(agents, frame_history=FRAME_HISTORY, logger=logger,
                   type=args.model_name, collective_rewards=args.team_reward, attention=args.attention)
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         model = dqn.q_network
-        model.load_state_dict(torch.load(args.load, map_location=model.device))
+        model.load_state_dict(torch.load(args.load, map_location=device))
+        model.to(device)
+        model.eval()
         environment = get_player(files_list=args.files,
                                  file_type=args.file_type,
                                  landmark_ids=args.landmarks,

--- a/src/DQN.py
+++ b/src/DQN.py
@@ -78,6 +78,10 @@ if __name__ == '__main__':
 
     parser.add_argument('--load', help='Path to the model to load')
     parser.add_argument(
+        '--resume',
+        help='Path to a checkpoint file to resume training from',
+        default=None, type=str)
+    parser.add_argument(
         '--task',
         help='''task to perform,
                 must load a pretrained model if task is "play" or "eval"''',
@@ -209,8 +213,8 @@ if __name__ == '__main__':
                             \'landmarks.txt\'] """
         assert len(args.files) == 2, (error_message)
 
-    if args.seed is not None:
-        set_reproducible(args.seed)
+    if args.resume is not None and args.task != 'train':
+        print(f"Warning: --resume is only used for --task train, ignoring --resume.")
 
     logger = Logger(args.log_dir, args.write, args.save_freq, comment=args.log_comment)
 
@@ -235,6 +239,11 @@ if __name__ == '__main__':
                               args.steps_per_episode)
         evaluator.play_n_episodes(fixed_spawn=args.fixed_spawn)
     else:  # train model
+        checkpoint = None
+        if args.resume is not None:
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+            checkpoint = torch.load(args.resume, map_location=device)
+            print(f"Loaded checkpoint from: {args.resume}")
         environment = get_player(task='train',
                                  files_list=args.files,
                                  file_type=args.file_type,
@@ -270,5 +279,6 @@ if __name__ == '__main__':
                           attention=args.attention,
                           lr=args.lr,
                           scheduler_gamma=args.scheduler_gamma,
-                          scheduler_step_size=args.scheduler_step_size
+                          scheduler_step_size=args.scheduler_step_size,
+                          checkpoint=checkpoint
                          ).train()

--- a/src/DQNModel.py
+++ b/src/DQNModel.py
@@ -308,6 +308,18 @@ class DQN:
     def copy_to_target_network(self):
         self.target_network.load_state_dict(self.q_network.state_dict())
 
+    def save_checkpoint(self, name="checkpoint.pt", episode=0, eps=1.0, acc_steps=0, forced=False):
+        checkpoint = {
+            'q_network_state_dict': self.q_network.state_dict(),
+            'target_network_state_dict': self.target_network.state_dict(),
+            'optimiser_state_dict': self.optimiser.state_dict(),
+            'scheduler_state_dict': self.scheduler.state_dict(),
+            'episode': episode,
+            'eps': eps,
+            'acc_steps': acc_steps,
+        }
+        self.logger.save_model(checkpoint, name, forced)
+
     def save_model(self, name="dqn.pt", forced=False):
         self.logger.save_model(self.q_network.state_dict(), name, forced)
 

--- a/src/evaluator.py
+++ b/src/evaluator.py
@@ -67,18 +67,19 @@ class Evaluator(object):
         return mean, std
 
     def play_one_episode(self, render=False, frame_history=4, fixed_spawn=None):
-
+        device = next(self.model.parameters()).device
         def predict(obs_stack):
             """
             Run a full episode, mapping observation to action,
             using greedy policy.
             """
-            inputs = torch.tensor(obs_stack).permute(
-                0, 4, 1, 2, 3).unsqueeze(0)
-            q_vals = self.model.forward(inputs).detach().squeeze(0)
+            inputs = torch.from_numpy(obs_stack).float().permute(
+                0, 4, 1, 2, 3).unsqueeze(0).to(device)
+            with torch.no_grad(): 
+                q_vals = self.model(inputs)
             idx = torch.max(q_vals, -1)[1]
             greedy_steps = np.array(idx, dtype=np.int32).flatten()
-            return greedy_steps, q_vals.data.numpy()
+            return greedy_steps, q_vals.detach().cpu().numpy()
 
         obs_stack = self.env.reset(fixed_spawn)
         # Here obs have shape (agent, *image_size, frame_history)

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -30,7 +30,8 @@ class Trainer(object):
                  attention=False,
                  lr=1e-3,
                  scheduler_gamma=0.5,
-                 scheduler_step_size=100
+                 scheduler_step_size=100,
+                 checkpoint=None
                 ):
         self.env = env
         self.eval_env = eval_env
@@ -66,19 +67,38 @@ class Trainer(object):
             scheduler_gamma=scheduler_gamma,
             scheduler_step_size=scheduler_step_size)
         self.dqn.q_network.train(True)
+        self.logger = logger
+        self.train_freq = train_freq
+        self.start_episode = 1
+        self.start_acc_steps = 0
+        self.start_eps = eps
+
+        if checkpoint is not None:
+            if self.logger:
+                self.logger.log("Restoring from checkpoint...")
+            self.dqn.q_network.load_state_dict(checkpoint['q_network_state_dict'])
+            if 'target_network_state_dict' in checkpoint:
+                self.dqn.target_network.load_state_dict(checkpoint['target_network_state_dict'])
+            if 'optimiser_state_dict' in checkpoint:
+                self.dqn.optimiser.load_state_dict(checkpoint['optimiser_state_dict'])
+            if 'scheduler_state_dict' in checkpoint:
+                self.dqn.scheduler.load_state_dict(checkpoint['scheduler_state_dict'])
+            self.start_episode = checkpoint.get('episode', 0) + 1
+            self.start_acc_steps = checkpoint.get('acc_steps', 0)
+            self.start_eps = checkpoint.get('eps', self.eps)
+            if self.logger:
+                self.logger.log(f"Resumed from episode {checkpoint.get('episode', 0)}, step {checkpoint.get('acc_steps', 0)}")
         self.evaluator = Evaluator(eval_env,
                                    self.dqn.q_network,
                                    logger,
                                    self.agents,
                                    steps_per_episode)
-        self.logger = logger
-        self.train_freq = train_freq
-
     def train(self):
         self.logger.log(self.dqn.q_network)
         self.init_memory()
-        episode = 1
-        acc_steps = 0
+        episode = self.start_episode
+        acc_steps = self.start_acc_steps
+        self.eps = self.start_eps
         epoch_distances = []
         while episode <= self.max_episodes:
             # Reset the environment for the start of the episode.
@@ -116,6 +136,12 @@ class Trainer(object):
                                         "train", episode)
                 self.validation_epoch(episode)
                 self.dqn.save_model(name="latest_dqn.pt", forced=True)
+                self.dqn.save_checkpoint(
+                    name="latest_checkpoint.pt",
+                    episode=episode,
+                    eps=self.eps,
+                    acc_steps=acc_steps,
+                    forced=True)
                 self.dqn.scheduler.step()
                 epoch_distances = []
             episode += 1


### PR DESCRIPTION
in response to #25 

have been working on this lately, 

so i have added checkpointing support to the training pipeline so that training progress can be saved and resumed instead of starting from scratch as discussed before,

now model state will be saved along with optimizer, scheduler and basic training metadata so it can pick up from where it left off

also added support for resuming training using a checkpoint file and wired it into the existing training loop

(didn’t removed the --load flag since it serves a different purpose than --resume, --load is still needed for eval/play where we just want to load a trained model and run inference while --resume is specifically for continuing training from a checkpoint)

i have tried my best to cover all edge cases and compatibility issues, please do let me know in case of any discrepancy